### PR TITLE
pom: source/target compliance, file encoding

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -6,6 +6,13 @@
     <groupId>ch.threema.apitool</groupId>
     <artifactId>msgapi-sdk-java</artifactId>
     <version>1.0.2</version>
+
+	<properties>
+		<source.encoding>UTF-8</source.encoding>
+		<project.build.sourceEncoding>${source.encoding}</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>${source.encoding}</project.reporting.outputEncoding>
+	</properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -29,6 +36,15 @@
 				<configuration>
 					<source>8</source>
 					<target>8</target>
+					<encoding>${source.encoding}</encoding>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.5</version>
+				<configuration>
+					<encoding>${source.encoding}</encoding>
 				</configuration>
 			</plugin>
             <plugin>

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -22,6 +22,15 @@
     <name>Threema MsgApi SDK</name>
     <build>
         <plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>8</source>
+					<target>8</target>
+				</configuration>
+			</plugin>
             <plugin>
                 <!-- Build an executable JAR -->
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Hi folks, since I worked with a default 1.6 jdk, my own console build of the messaging sdk failed. So I had to adjust the maven pom to get things compiling.

What'd you think, is this useful?

One open point there still is, though: by locking down the plugin version to 3.3, i implicitely fix the needed maven version to 3. Probably we could leave the version out to be more flexible there.
