### PR TITLE
Plugins and some config to release to maven central

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -43,13 +43,13 @@
   
     <url>https://gateway.threema.ch/de</url>
 
-      <licenses>
-        <license>
-          <name>MIT-License</name>
-          <url>http://opensource.org/licenses/mit-license.php</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
+  <licenses>
+    <license>
+      <name>MIT-License</name>
+      <url>http://opensource.org/licenses/mit-license.php</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
     <dependencies>
         <dependency>

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -3,9 +3,26 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>org.sonatype.oss</groupId>
+      <artifactId>oss-parent</artifactId>
+      <version>7</version>
+    </parent>
+    
     <groupId>ch.threema.apitool</groupId>
     <artifactId>msgapi-sdk-java</artifactId>
     <version>1.0.2</version>
+    <name>Threema MsgApi SDK</name>
+
+    <!-- Documentation on how to get this to maven central: -->
+    <!-- https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide#SonatypeOSSMavenRepositoryUsageGuide-7b.StageExistingArtifacts -->
+    <!-- http://central.sonatype.org/pages/ossrh-guide.html -->
+
+    <issueManagement>
+      <system>github issues</system>
+      <url>https://github.com/threema-ch/threema-msgapi-sdk-java/issues</url>
+    </issueManagement>
 
 	<properties>
 		<source.encoding>UTF-8</source.encoding>
@@ -26,14 +43,13 @@
   
     <url>https://gateway.threema.ch/de</url>
 
-  <licenses>
-    <license>
-      <name>MIT-License</name>
-      <url>http://opensource.org/licenses/mit-license.php</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  
+      <licenses>
+        <license>
+          <name>MIT-License</name>
+          <url>http://opensource.org/licenses/mit-license.php</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
 
     <dependencies>
         <dependency>
@@ -48,7 +64,7 @@
             <version>2.8</version>
         </dependency>
     </dependencies>
-    <name>Threema MsgApi SDK</name>
+    
     <build>
         <plugins>
 			<plugin>
@@ -69,6 +85,7 @@
 					<encoding>${source.encoding}</encoding>
 				</configuration>
 			</plugin>
+      
             <plugin>
                 <!-- Build an executable JAR -->
                 <groupId>org.apache.maven.plugins</groupId>
@@ -84,6 +101,37 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <!-- plugins for releasing to maven central. -->
+            <plugin>
+          
+              <!-- for staging to sonatype nexus -->
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nexus-staging-maven-plugin</artifactId>
+              <version>1.6.3</version>
+              <extensions>true</extensions>
+              <configuration>
+                <serverId>ossrh</serverId>
+                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              </configuration>
+            </plugin>
+          
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>1.5</version>
+              <executions>
+                <execution>
+                  <id>sign-artifacts</id>
+                  <phase>verify</phase>
+                  <goals>
+                    <goal>sign</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Releasing to maven central has some advantages:
- developers who want to use your API donnot have to download and build all the sources
- you can establish a proper change nmanagement and release cycle (raising a version in a doc is no proper change management)

Unfortunately, it's way complicated the first time to get things up and running.  On a high level the way is as follows:
- publish to a snapshot repository at sonatype oss nexus
- review files
- publish a release (no -SNAPSHOT) to a release repository at sonatype oss nexus
- review those files too
- close the release repository, transfer to maven normally happens at night.
- review the results on maven central

For each artifact, you need:
- the jar with compiled stuff
- the -sources file generated with 
  
  > mvn sources:jar
- the -javadoc file generated with 
  
  > mvn javadoc:jar
- a checksum file

What do you still need (and I cant do that foor you):
- a public / private gpg key to sign jars
- an account at sonatype oss  nexus

Then, review the html pages I inserted as comments on top of the pom.

When everything is set up once, things happen automatically most way.

Feel free to ask.
